### PR TITLE
Sort mac address to have same list whatever the kernel report

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ for zero-os
 It uses the following information to seed the identity generation:
 - Constant Seed
 - Motherboard ID (if available)
-- All the mac addresses of the *physical* attached devices
+- All the mac addresses of the *physical* attached devices, sorted
 
 > This means that a change in HW will generate a new ID
 

--- a/generate.go
+++ b/generate.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"unsafe"
 )
@@ -54,13 +55,25 @@ func GetMachineIdentity() (public, secret string) {
 		sh.Write(bytes.TrimSpace(data))
 	}
 
+	devices := []string{}
+
 	//all physical devices.
 	for _, link := range links {
 		if link.Type() != "device" {
 			continue
 		}
 
-		io.WriteString(sh, link.Attrs().HardwareAddr.String())
+		devices = append(devices, link.Attrs().HardwareAddr.String())
+
+	}
+
+	// don't rely on the order of nics
+	// we sort the list to ensure it's the same
+	// whatever the kernel does
+	sort.Strings(devices)
+
+	for _, dev := range devices {
+		io.WriteString(sh, dev)
 	}
 
 	secret = Generate(sh.Sum(nil))


### PR DESCRIPTION
In order to ensure across reboot, the list of mac address doesn't change, we sort it